### PR TITLE
fix(ui): prevent text overflow in vertical bar

### DIFF
--- a/AiOverviewControlWidget.qml
+++ b/AiOverviewControlWidget.qml
@@ -1982,26 +1982,13 @@ PluginComponent {
             Repeater {
                 model: root.pillDisplayProviders.length > 0 ? root.pillDisplayProviders : (root.hasProviderData ? [root.providerData] : [])
 
-                Row {
+                StyledText {
                     required property var modelData
-                    spacing: 4
+                    text: `${Math.round(root.providerPercent(modelData))}%`
+                    color: root.providerAccent(modelData.provider)
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
-
-                    Rectangle {
-                        width: 6
-                        height: 6
-                        radius: 3
-                        color: root.providerAccent(modelData.provider)
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    StyledText {
-                        text: `${Math.round(root.providerPercent(modelData))}%`
-                        color: root.getUsageColor(root.providerPercent(modelData))
-                        font.pixelSize: Theme.fontSizeSmall
-                        font.weight: Font.DemiBold
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
                 }
             }
 

--- a/AiOverviewControlWidget.qml
+++ b/AiOverviewControlWidget.qml
@@ -1982,13 +1982,26 @@ PluginComponent {
             Repeater {
                 model: root.pillDisplayProviders.length > 0 ? root.pillDisplayProviders : (root.hasProviderData ? [root.providerData] : [])
 
-                StyledText {
+                Row {
                     required property var modelData
-                    text: `${Math.round(root.providerPercent(modelData))}%`
-                    color: root.getUsageColor(root.providerPercent(modelData))
-                    font.pixelSize: Theme.fontSizeSmall
-                    font.weight: Font.DemiBold
+                    spacing: 4
                     anchors.horizontalCenter: parent.horizontalCenter
+
+                    Rectangle {
+                        width: 6
+                        height: 6
+                        radius: 3
+                        color: root.providerAccent(modelData.provider)
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    StyledText {
+                        text: `${Math.round(root.providerPercent(modelData))}%`
+                        color: root.getUsageColor(root.providerPercent(modelData))
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: Font.DemiBold
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
             }
 

--- a/AiOverviewControlWidget.qml
+++ b/AiOverviewControlWidget.qml
@@ -1984,7 +1984,7 @@ PluginComponent {
 
                 StyledText {
                     required property var modelData
-                    text: `${root.providerName(modelData.provider)} ${Math.round(root.providerPercent(modelData))}%`
+                    text: `${Math.round(root.providerPercent(modelData))}%`
                     color: root.getUsageColor(root.providerPercent(modelData))
                     font.pixelSize: Theme.fontSizeSmall
                     font.weight: Font.DemiBold

--- a/AiOverviewControlWidget.qml
+++ b/AiOverviewControlWidget.qml
@@ -1952,7 +1952,7 @@ PluginComponent {
                             width: 7
                             height: 7
                             radius: 3.5
-                            color: pillEntry.usageColor
+                            color: root.providerAccent(pillEntry.modelData.provider)
                             anchors.verticalCenter: parent.verticalCenter
 
                             Behavior on color { ColorAnimation { duration: 200 } }

--- a/AiOverviewControlWidget.qml
+++ b/AiOverviewControlWidget.qml
@@ -287,6 +287,13 @@ PluginComponent {
     }
 
     readonly property var providerData: {
+        for (let i = 0; i < pinnedProviders.length; i++) {
+            for (let j = 0; j < successfulProviders.length; j++) {
+                if (successfulProviders[j].provider === pinnedProviders[i]) {
+                    return successfulProviders[j];
+                }
+            }
+        }
         let bestProvider = null;
         let bestPercent = -1;
         for (let i = 0; i < successfulProviders.length; i++) {
@@ -1886,11 +1893,34 @@ PluginComponent {
                 border.color: Theme.withAlpha(root.heroAccent, 0.28)
                 anchors.verticalCenter: parent.verticalCenter
 
-                DankIcon {
+                Canvas {
                     anchors.centerIn: parent
-                    name: "monitoring"
-                    size: 14
-                    color: root.heroAccent
+                    width: 20
+                    height: 20
+                    renderStrategy: Canvas.Cooperative
+                    property real percent: root.primaryPercent
+                    property color accent: root.heroAccent
+                    onPercentChanged: requestPaint()
+                    onAccentChanged: requestPaint()
+                    onPaint: {
+                        var ctx = getContext("2d");
+                        ctx.reset();
+                        var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5;
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                        ctx.lineWidth = lw;
+                        ctx.strokeStyle = Theme.withAlpha(root.heroAccent, 0.2);
+                        ctx.stroke();
+                        var pct = percent / 100;
+                        if (pct > 0) {
+                            ctx.beginPath();
+                            ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                            ctx.lineWidth = lw;
+                            ctx.strokeStyle = root.heroAccent;
+                            ctx.lineCap = "round";
+                            ctx.stroke();
+                        }
+                    }
                 }
             }
 
@@ -1971,11 +2001,34 @@ PluginComponent {
                 border.color: Theme.withAlpha(root.heroAccent, 0.28)
                 anchors.horizontalCenter: parent.horizontalCenter
 
-                DankIcon {
+                Canvas {
                     anchors.centerIn: parent
-                    name: "monitoring"
-                    size: 13
-                    color: root.heroAccent
+                    width: 20
+                    height: 20
+                    renderStrategy: Canvas.Cooperative
+                    property real percent: root.primaryPercent
+                    property color accent: root.heroAccent
+                    onPercentChanged: requestPaint()
+                    onAccentChanged: requestPaint()
+                    onPaint: {
+                        var ctx = getContext("2d");
+                        ctx.reset();
+                        var cx = width / 2, cy = height / 2, r = 7.5, lw = 2.5;
+                        ctx.beginPath();
+                        ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+                        ctx.lineWidth = lw;
+                        ctx.strokeStyle = Theme.withAlpha(root.heroAccent, 0.2);
+                        ctx.stroke();
+                        var pct = percent / 100;
+                        if (pct > 0) {
+                            ctx.beginPath();
+                            ctx.arc(cx, cy, r, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * Math.min(pct, 1));
+                            ctx.lineWidth = lw;
+                            ctx.strokeStyle = root.heroAccent;
+                            ctx.lineCap = "round";
+                            ctx.stroke();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
When the widget is placed in a vertical panel, the text pill (which originally rendered as `ProviderName 85%`) was too wide and caused horizontal overflow. This PR simplifies the vertical bar text to only show the numeric percentage (e.g., `85%`), relying on the pill's background color to identify the provider. This ensures a clean layout in vertical environments.