### PR TITLE
fix(settings): use store installation path in diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,17 @@ jobs:
             AiOverviewControlI18n.qml \
             ProviderLogo.qml
 
+      - name: No hardcoded install path in QML
+        run: |
+          # DMS plugin-store installs land under the manifest id ("aiOverviewControl"),
+          # not the display name ("AiOverviewControl") — Linux paths are case-sensitive.
+          # QML must resolve its own directory (PluginService.getPluginPath / Qt.resolvedUrl)
+          # instead of hardcoding either casing, so this stays correct for both install methods.
+          if grep -rnE 'plugins/[Aa]iOverviewControl' -- *.qml; then
+            echo "::error::Found a hardcoded plugin install path in QML — resolve it via PluginService.getPluginPath()/Qt.resolvedUrl() instead" >&2
+            exit 1
+          fi
+
   # ─── crowdin ─────────────────────────────────────────────────────────────────
   crowdin:
     name: Crowdin config

--- a/AiOverviewControlSettings.qml
+++ b/AiOverviewControlSettings.qml
@@ -70,6 +70,12 @@ PluginSettings {
         pinnedIds = result;
         saveValue("pinnedProviders", result.join(","));
     }
+    // Resolved imperatively in Component.onCompleted — Qt.resolvedUrl is only reliable
+    // when called from the file's own execution context, not from a declarative binding.
+    // Store installs place the plugin under its manifest id (e.g. "aiOverviewControl"),
+    // which is not necessarily the display-name casing used by manual checkouts, so
+    // this must never be a hardcoded literal.
+    property string _pluginDir: ""
     property var providerHealth: ({})
     property string healthBuffer: ""
     property string healthScript: ""
@@ -200,6 +206,20 @@ PluginSettings {
     }
 
     Component.onCompleted: {
+        // 1. Try PluginService (authoritative, case-correct)
+        if (pluginService && pluginId) {
+            const fromService = pluginService.getPluginPath(pluginId);
+            if (fromService && fromService.length > 0) {
+                _pluginDir = fromService;
+            }
+        }
+        // 2. Fallback: derive from this file's URL (Qt.resolvedUrl is reliable here)
+        if (!_pluginDir) {
+            const selfUrl = Qt.resolvedUrl("AiOverviewControlSettings.qml").toString();
+            const withoutScheme = selfUrl.startsWith("file://") ? selfUrl.substring(7) : selfUrl;
+            const lastSlash = withoutScheme.lastIndexOf("/");
+            _pluginDir = lastSlash !== -1 ? withoutScheme.substring(0, lastSlash) : withoutScheme;
+        }
         const url = Qt.resolvedUrl("providers/get-provider-health").toString();
         healthScript = url.startsWith("file://") ? url.substring(7) : url;
         runHealth();
@@ -752,12 +772,12 @@ PluginSettings {
             spacing: Theme.spacingM
             Repeater {
                 model: [
-                    { label:t("settings.test_backend", "Test selected providers"), cmd:"PLUGIN=~/.config/DankMaterialShell/plugins/AiOverviewControl\n$PLUGIN/providers/get-provider-usage \"" + root.selectedIds.join(",") + "\" $PLUGIN/providers/get-copilot-usage | jq ." },
-                    { label:t("settings.test_codex", "Test Codex app-server adapter"), cmd:"~/.config/DankMaterialShell/plugins/AiOverviewControl/providers/get-codex-usage | jq ." },
-                    { label:t("settings.test_pi", "Test pi session analytics adapter"), cmd:"~/.config/DankMaterialShell/plugins/AiOverviewControl/providers/get-pi-analytics | jq ." },
-                    { label:t("settings.test_health", "Check provider prerequisites"), cmd:"~/.config/DankMaterialShell/plugins/AiOverviewControl/providers/get-provider-health \"" + root.selectedIds.join(",") + "\" | jq ." },
+                    { label:t("settings.test_backend", "Test selected providers"), cmd:root._pluginDir + "/providers/get-provider-usage \"" + root.selectedIds.join(",") + "\" " + root._pluginDir + "/providers/get-copilot-usage | jq ." },
+                    { label:t("settings.test_codex", "Test Codex app-server adapter"), cmd:root._pluginDir + "/providers/get-codex-usage | jq ." },
+                    { label:t("settings.test_pi", "Test pi session analytics adapter"), cmd:root._pluginDir + "/providers/get-pi-analytics | jq ." },
+                    { label:t("settings.test_health", "Check provider prerequisites"), cmd:root._pluginDir + "/providers/get-provider-health \"" + root.selectedIds.join(",") + "\" | jq ." },
                     { label:t("settings.test_deps", "Check core dependencies"), cmd:"command -v bash jq curl codex claude pi gh gcloud ollama" },
-                    { label:t("settings.test_qml", "Validate QML"), cmd:"qmllint ~/.config/DankMaterialShell/plugins/AiOverviewControl/AiOverviewControlWidget.qml ~/.config/DankMaterialShell/plugins/AiOverviewControl/AiOverviewControlSettings.qml" }
+                    { label:t("settings.test_qml", "Validate QML"), cmd:"qmllint " + root._pluginDir + "/AiOverviewControlWidget.qml " + root._pluginDir + "/AiOverviewControlSettings.qml" }
                 ]
                 delegate: Column {
                     id: diagRow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Settings
+
+- Fixed the diagnostic commands in Settings ("Test selected providers", "Test Codex app-server adapter", "Test pi session analytics adapter", "Check provider prerequisites", "Validate QML") hardcoding the `AiOverviewControl` display-name casing instead of the manifest id `aiOverviewControl` used by DMS plugin-store installs. Settings now resolves its own install directory the same way the widget already did (`PluginService.getPluginPath`, with a `Qt.resolvedUrl` fallback), so copied commands always match the actual on-disk path regardless of install method.
+
 ## 1.9.0 - 2026-08-06
 
 ### pi coding-agent local analytics provider

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,15 @@
 # Troubleshooting
 
+The `PLUGIN=` path below matches a manual checkout or release-archive install
+(see [installation](./installation.md)), which uses the `AiOverviewControl`
+display-name casing. A DMS plugin-store install instead uses the manifest id
+and lands at `~/.config/DankMaterialShell/plugins/aiOverviewControl`
+(lowercase leading `a`) — Linux paths are case-sensitive, so adjust the
+`PLUGIN=` line below to match whichever directory `ls
+~/.config/DankMaterialShell/plugins` actually shows. The commands shown in the
+plugin's own Settings panel always use the correct path for your install
+automatically.
+
 ## No cards appear
 
 ```bash


### PR DESCRIPTION
## Summary

`plugin.json`'s manifest id is `aiOverviewControl`, and that's the directory name DMS's plugin store installs the plugin under. The Settings diagnostic commands ("Test selected providers", "Test Codex app-server adapter", "Test pi session analytics adapter", "Check provider prerequisites", "Validate QML") instead hardcoded the display-name casing, `AiOverviewControl`. On a case-sensitive filesystem that path doesn't exist for a store install, so every copied command fails with `no such file or directory` until the user manually fixes the casing (or lets Zsh tab-completion do it for them).

The widget (`AiOverviewControlWidget.qml`) already solved this in 1.2.2 via `PluginService.getPluginPath(pluginId)` with a `Qt.resolvedUrl` fallback — Settings never got the same treatment. This PR applies the identical, already-proven pattern to `AiOverviewControlSettings.qml` and rebuilds every diagnostic command from the resolved `_pluginDir` instead of a literal path.

- Doc paths under `docs/installation.md`, `README.md`, and `docs/README.pt-BR.md` are left as-is: they document a manual checkout/archive install where the user themselves creates the `AiOverviewControl`-cased directory, so that casing is correct there.
- Added a short clarifying note to `docs/troubleshooting.md`'s manual `PLUGIN=` snippet, since a store-installed user could otherwise hit the same casing mismatch when following it.
- Added a CI check (`.github/workflows/ci.yml`, QML lint job) that fails if any `.qml` file hardcodes `plugins/AiOverviewControl` or `plugins/aiOverviewControl` again — confirmed it fails against the pre-fix file and passes against this branch.

## Test plan

- [x] `qmllint AiOverviewControlWidget.qml AiOverviewControlSettings.qml AiOverviewControlI18n.qml ProviderLogo.qml` — exit 0
- [x] Reproduced the bug: `~/.config/DankMaterialShell/plugins/AiOverviewControl/providers/get-codex-usage` → `no such file or directory` (exit 127) on a store install at `plugins/aiOverviewControl`
- [x] Ran the corrected path directly: `~/.config/DankMaterialShell/plugins/aiOverviewControl/providers/get-codex-usage | jq .` → succeeds
- [x] Ran `~/.config/DankMaterialShell/plugins/aiOverviewControl/providers/get-provider-health "codex,claude,copilot" | jq .` → succeeds
- [x] `rg -n 'plugins/AiOverviewControl|plugins/aiOverviewControl' .` reviewed — only manual-install docs remain
- [x] New CI grep check verified to fail against the pre-fix QML and pass against this branch