### PR TITLE
ci(qml): harden install-path checks + credit #13 contributor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,10 +551,42 @@ jobs:
           # not the display name ("AiOverviewControl") — Linux paths are case-sensitive.
           # QML must resolve its own directory (PluginService.getPluginPath / Qt.resolvedUrl)
           # instead of hardcoding either casing, so this stays correct for both install methods.
-          if grep -rnE 'plugins/[Aa]iOverviewControl' -- *.qml; then
+          # Recursive + --include so it also catches QML files moved into
+          # subdirectories later, not just the root-level set qmllint lints.
+          if grep -rnE 'plugins/[Aa]iOverviewControl' --include='*.qml' .; then
             echo "::error::Found a hardcoded plugin install path in QML — resolve it via PluginService.getPluginPath()/Qt.resolvedUrl() instead" >&2
             exit 1
           fi
+
+      - name: QML provider-script references resolve
+        run: |
+          python3 - <<'PY'
+          import re, stat, sys
+          from pathlib import Path
+
+          # The Settings/Widget diagnostics build their commands from
+          # `_pluginDir + "/providers/<script>"`, so every provider script
+          # referenced from QML must exist and be executable — a renamed or
+          # removed helper would otherwise silently produce a broken
+          # copy-to-clipboard command. Mirrors the cross-file style of the
+          # "Provider dispatch coverage" check in the shell job.
+          refs = set()
+          for qml in Path('.').rglob('*.qml'):
+              for m in re.finditer(r'providers/([A-Za-z0-9][A-Za-z0-9._-]*)', qml.read_text()):
+                  refs.add(m.group(1))
+
+          errors = []
+          for name in sorted(refs):
+              p = Path('providers') / name
+              if not p.is_file():
+                  errors.append(f'Referenced from QML but not a regular file: providers/{name}')
+              elif not (p.stat().st_mode & stat.S_IXUSR):
+                  errors.append(f'Referenced from QML but not executable: providers/{name}')
+
+          print(f'QML references {len(refs)} provider script(s): {", ".join(sorted(refs))}')
+          if errors:
+              sys.exit('\n'.join(f'::error::{e}' for e in errors))
+          PY
 
   # ─── crowdin ─────────────────────────────────────────────────────────────────
   crowdin:

--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ provider contract.
 | Release checklist | [docs/release-checklist.md](./docs/release-checklist.md) |
 | Changelog | [CHANGELOG.md](./CHANGELOG.md) |
 
+## Contributors
+
+Thanks to everyone who has improved the plugin:
+
+- **[@emmsixx](https://github.com/emmsixx)** — fixed the Settings diagnostic commands hardcoding the display-name casing (`AiOverviewControl`) instead of the DMS plugin-store manifest id (`aiOverviewControl`), so copied commands resolve correctly on case-sensitive filesystems ([#13](https://github.com/bernardopg/AiOverviewControl/pull/13)).
+
+Contributions welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ---
 
 <div align="center">

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -273,6 +273,14 @@ normalizado de provedores.
 | Checklist de release | [release-checklist.md](./release-checklist.md) |
 | Changelog | [CHANGELOG.md](../CHANGELOG.md) |
 
+## Colaboradores
+
+Agradecemos a todos que melhoraram o plugin:
+
+- **[@emmsixx](https://github.com/emmsixx)** — corrigiu os comandos de diagnóstico em Settings que codificavam o casing do nome de exibição (`AiOverviewControl`) em vez do id de manifesto da loja de plugins do DMS (`aiOverviewControl`), de modo que os comandos copiados resolvam corretamente em sistemas de arquivos sensíveis a maiúsculas/minúsculas ([#13](https://github.com/bernardopg/AiOverviewControl/pull/13)).
+
+Contribuições são bem-vindas — veja [CONTRIBUTING.md](../CONTRIBUTING.md).
+
 ---
 
 <div align="center">


### PR DESCRIPTION
Follow-up to **#13** (merged) — small, surgical hardening of the CI gate that PR introduced, plus a Contributors section recognizing @emmsixx.

## 1. Tighten the “No hardcoded install path in QML” gate

`#13` added a `grep` step that fails if any QML hardcodes `plugins/AiOverviewControl` / `plugins/aiOverviewControl`. Two small robustness improvements:

- **Recursive + `--include='*.qml'`** instead of `-- *.qml`, so the check still fires if QML files ever move into a subdirectory — not just the root-level set `qmllint` lints.

## 2. New structural check: `QML provider-script references resolve`

Mirrors the shell job’s “Provider dispatch coverage” cross-check style. The Settings/Widget diagnostics build their copy-to-clipboard commands from `_pluginDir + "/providers/<script>"`, so every `providers/<script>` referenced from any `.qml` must exist **and** be executable. A renamed or removed helper would otherwise silently produce a broken command.

Verified the gate is real: it fails (exit 1) on both a dangling reference and a non-executable file.

| Scenario | Result |
| --- | --- |
| Current tree (9 refs) | ✅ pass |
| Injected dangling `providers/get-nonexistent-script` | ❌ fail |
| `providers/get-codex-usage` made non-executable | ❌ fail |

## 3. Credit the contributor

Adds a **Contributors** section to `README.md` recognizing @emmsixx for the store-install-path fix (#13) — the plugin’s first external contribution.

---

No QML changed; `qmllint` (all 4 files) and the new checks pass on this branch.